### PR TITLE
chore: CI 설정 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,6 @@ jobs:
 
       - name: Install deps
         run: npm ci --ignore-scripts
-        env:
-          HUSKY: 0
 
       - name: Lint
         run: npm run lint


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #2

---

## ✨ 작업 내용

- PR에서 lint/build CI 추가했습니다.

🛠 이슈 & 해결

- CI에서 `npm ci` 중 `husky (prepare)` 실행으로 오류 발생
- CI 환경에서는 husky가 필요 없어서 `npm ci --ignore-scripts`로 install 단계에서 스크립트 실행을 제외해 해결

✅ 현재 상태

- PR에서 lint / build 정상 실행 및 통과
- 로컬 개발 환경(husky, lint-staged)에는 영향 없음

---

## 👀 리뷰 포인트

- 최초 PR 후 main merge 해서 CI 작동이 돼야 Settings 설정이 가능하다고 하길래 해당 PR은 우선 머지했습니다.
- 이후 작업 PR 올릴 때 Actions 작동하는지 확인해주세요.
- Settings>Branches에서 approvals 1명 이상, status check 설정해서 머지 막아두었습니다.
  - CI 실패 시 Merge 버튼 비활성화 되는지
  - CI 성공 시 머지 가능한지 확인 부탁드립니다.